### PR TITLE
Correction caractère typographique et code Linky.

### DIFF
--- a/api_compteur_tic.py
+++ b/api_compteur_tic.py
@@ -333,10 +333,12 @@ with PidFile(pidname="api_compteur_tic"):
 
     # affectation des callbacks :
     decodeur_trames.set_cb_nouvelle_trame_recue_tt_trame(interpreteur_trames.interpreter_trame)
-    decodeur_trames.set_cb_debut_interruption(cb_debut_interruption)
-    decodeur_trames.set_cb_fin_interruption(cb_fin_interruption)
     decodeur_trames.set_cb_mauvaise_trame_recue(cb_mauvaise_trame_recue)
     pickles_etat.set_callback(cb_sauvegarde_etat)
+
+    if type_compteur == 'pmepmi':
+            decodeur_trames.set_cb_debut_interruption(cb_debut_interruption)
+            decodeur_trames.set_cb_fin_interruption(cb_fin_interruption)
 
     # lecture de l'etat sauvegarde et demarrage de la sauvegarde periodique :
     etat_sauve = pickles_etat.get_data()

--- a/decode_linky.py
+++ b/decode_linky.py
@@ -119,11 +119,10 @@ class DecodeCompteurLinky():
         self._ID_ETAT_ATTENTE_DEBUT_TRAME = 1
         self._ID_ETAT_ATTENTE_DEBUT_GROUPE = 2
         self._ID_ETAT_TRAITEMENT_GROUPE = 3
-        self._ID_ETAT_INTERRUPTION = 4
         self._dict_etat = {self._ID_ETAT_ATTENTE_DEBUT_TRAME : "Attente debut trame",
                            self._ID_ETAT_ATTENTE_DEBUT_GROUPE : "Attente debut groupe",
-                           self._ID_ETAT_TRAITEMENT_GROUPE : "Traitement groupe",
-                           self._ID_ETAT_INTERRUPTION : "Interruption"}
+                           self._ID_ETAT_TRAITEMENT_GROUPE : "Traitement groupe"
+                           }
 
         self._dict_transitions = defaultdict(dict)
         self._dict_fonctions_etats = defaultdict(dict)
@@ -133,8 +132,6 @@ class DecodeCompteurLinky():
 
         self._dernier_octet = " "
         self._tampon_groupe = ""
-        self._tampon_interruption = ""
-        self._tampon_derniere_interruption = ""
 
         self._checksums_groupes_bons = False
 
@@ -147,8 +144,6 @@ class DecodeCompteurLinky():
         self._t_derniere_trame_valide = []
 
         # On met les callbacks a False par defaut pour signifier la non affectation
-        self.__cb_debut_interruption = False
-        self.__cb_fin_interruption = False
         self.__cb_mauvaise_trame_recue = False
         self.__cb_nouvelle_trame_recue = False
         self.__cb_nouvelle_trame_recue_tt_trame = False
@@ -157,14 +152,6 @@ class DecodeCompteurLinky():
         self.__f_init_dict_transitions()
         self.__f_init_dict_fonctions_etats()
 
-    ### Begin. A supprimer si il n'y a pas d'interruption
-    def set_debut__interruption(self, fonction):
-            self.__cb_debut_interruption = fonction
-
-    def set_cb_fin_interruption(self, fonction):
-            self.__cb_fin_interruption = fonction
-    ### End
-
     def set_cb_mauvaise_trame_recue(self, fonction):
             """ Affectation du callback sur mauvaise trame recue """
             self.__cb_mauvaise_trame_recue = fonction
@@ -172,36 +159,26 @@ class DecodeCompteurLinky():
     def set_cb_nouvelle_trame_recue(self, fonction):
             self.__cb_nouvelle_trame_recue = fonction
 
-    def set_cb_nouvelle_trame_recue_tt_tramee(self, fonction):
+    def set_cb_nouvelle_trame_recue_tt_trame(self, fonction):
             self.__cb_nouvelle_trame_recue_tt_trame = fonction
 
     def get_derniere_trame_valide(self):
             """ Obtention de la derniere trame valide """
             return self._t_derniere_trame_valide
 
-    def get_tampon_interruption(self):
-            """ Obtention du tampon d'interruption """
-            self._tampon_derniere_interrution
-
-    ### Machine à etat à modifier si il n'y a pas d'interruption dans les trames
     def __f_init_dict_transitions(self):
-            """
+        """
         Initialisation du dictionnaire des transitions
-        Une transition vers l'etat interruption implique de perdre la trame normale en cours.
+        Normalement linky n'a pas d'interruption de trame
         Le dictionnaire est utilise comme suit :
             _dict_transitions = { etat_actuel : { char_entrant : (nouvel_etat, f_depuis_etat_actuel, f_vers_etat_futur, f_depuis_etat_actuel_vers_etat_futur) } }
         Remarque : le programme boucle sur le tuple [1:] pour executer les fonctions du tuple, on peut donc ajouter des fonctions a la chaine !
         """
-        self._dict_transitions[self._ID_ETAT_ATTENTE_DEBUT_TRAME]  [self._CHAR_STX] = \
+        self._dict_transitions[self._ID_ETAT_ATTENTE_DEBUT_TRAME]  [self._CHAR_STX] =   \
             (self._ID_ETAT_ATTENTE_DEBUT_GROUPE,
              self.__f_noop,
              self.__f_noop,
              self.__f_raz_nouvelle_trame)
-        self._dict_transitions[self._ID_ETAT_ATTENTE_DEBUT_TRAME]  [self._CHAR_EOT] = \
-            (self._ID_ETAT_INTERRUPTION,
-             self.__f_noop,
-             self.__f_debut_interruption,
-             self.__f_noop)
         self._dict_transitions[self._ID_ETAT_ATTENTE_DEBUT_GROUPE] [self._CHAR_LF]  = \
             (self._ID_ETAT_TRAITEMENT_GROUPE,
              self.__f_noop,
@@ -212,45 +189,19 @@ class DecodeCompteurLinky():
              self.__f_noop,
              self.__f_noop,
              self.__f_traitement_fin_de_trame)
-        self._dict_transitions[self._ID_ETAT_ATTENTE_DEBUT_GROUPE] [self._CHAR_EOT] = \
-            (self._ID_ETAT_INTERRUPTION,
-             self.__f_noop,
-             self.__f_debut_interruption,
-             self.__f_noop)
         self._dict_transitions[self._ID_ETAT_TRAITEMENT_GROUPE]    [self._CHAR_CR]  = \
             (self._ID_ETAT_ATTENTE_DEBUT_GROUPE,
              self.__f_noop,
              self.__f_noop,
              self.__f_traitement_fin_de_groupe)
-        self._dict_transitions[self._ID_ETAT_TRAITEMENT_GROUPE]    [self._CHAR_EOT] = \
-            (self._ID_ETAT_INTERRUPTION,
-             self.__f_noop,
-             self.__f_debut_interruption,
-             self.__f_noop)
-        self._dict_transitions[self._ID_ETAT_INTERRUPTION]         [self._CHAR_ETX] = \
-            (self._ID_ETAT_ATTENTE_DEBUT_TRAME,
-             self.__f_fin_interruption,
-             self.__f_noop,
-             self.__f_noop)
-        self._dict_transitions[self._ID_ETAT_INTERRUPTION]         [self._CHAR_STX] = \
-            (self._ID_ETAT_ATTENTE_DEBUT_GROUPE,
-             self.__f_fin_interruption,
-             self.__f_noop,
-             self.__f_raz_nouvelle_trame)
-        self._dict_transitions[self._ID_ETAT_INTERRUPTION]         [self._CHAR_EOT] = \
-            (self._ID_ETAT_INTERRUPTION,
-             self.__f_fin_interruption,
-             self.__f_debut_interruption,
-             self.__f_noop)
 
     def __f_init_dict_fonctions_etats(self):
-            """
-            Initialisation des fonctions internes aux etats (sans transition)
-            """
+        """
+        Initialisation des fonctions internes aux etats (sans transition)
+        """
         self._dict_fonctions_etats[self._ID_ETAT_ATTENTE_DEBUT_TRAME] = self.__f_noop
         self._dict_fonctions_etats[self._ID_ETAT_ATTENTE_DEBUT_GROUPE] = self.__f_noop
-        self._dict_fonctions_etats[self._ID_ETAT_TRAITEMENT_GROUPE] = self.__traitement_groupe
-        self._dict_fonctions_etats[self._ID_ETAT_INTERRUPTION] = self.__f_interruption
+        self._dict_fonctions_etats[self._ID_ETAT_TRAITEMENT_GROUPE] = self.__f_traitement_groupe
 
     def __f_noop(self):
             """ Fonction qui ne fait rien """
@@ -263,22 +214,6 @@ class DecodeCompteurLinky():
     def __f_traitement_groupe(self):
         """ Traitement d'un groupe (= ligne). """
         self._tampon_groupe = self._tampon_groupe + self._dernier_octet
-
-    def __f_interruption(self):
-        """ Traitement de l'interruption en cours """
-        self._tampon_interruption = self._tampon_interruption + self._dernier_octet
-
-    def __f_debut_interruption(self):
-        """ Traitement de debut d'interruption """
-        if self.__cb_debut_interruption != False:
-            self.__cb_debut_interruption()
-        self.__f_raz_nouvelle_trame()
-
-    def __f_fin_interruption(self):
-        """ Traitement de fin d'interruption """
-        self._tampon_derniere_interruption = self._tampon_interruption
-        if self.__cb_fin_interruption != False:
-            self.__cb_fin_interruption()
 
     def __f_traitement_fin_de_trame(self):
         """ Traitement sur fin de trame """
@@ -297,7 +232,6 @@ class DecodeCompteurLinky():
         """ Remise a zero des variables pour commencer le traitement d'une nouvelle trame """
         #print("RAZ nouvelle trame")
         self._tampon_groupe = ""
-        self._tampon_interruption = ""
         self._checksums_groupes_bons = True
         del self._t_trame_en_cours[:]
         self._t_trame_en_cours = []
@@ -339,7 +273,7 @@ class DecodeCompteurLinky():
             #print(self._dict_transitions[self._etat][self._dernier_octet][1])
             self._etat_precedent = self._etat
             self._etat = self._dict_transitions[self._etat][self._dernier_octet][0]
-            # charge dans fonction_transition les fonctions relatives à l'etat actuel et les execute. indice 1 car 0 stocke un nouvel etat
+            # charge dans fonction_transition les fonctions relatives a l'etat actuel et les execute. indice 1 car 0 stocke un nouvel etat
             for fonction_transition in self._dict_transitions[self._etat_precedent][self._dernier_octet][1:]:
                 fonction_transition()
         elif self._etat in self._dict_fonctions_etats:
@@ -363,29 +297,29 @@ class DecodeCompteurLinky():
         # on a besoin de 3 char au minimum
         if (len(self._tampon_groupe) > 3) \
            and (self._checksums_groupes_bons == True):
-           # Separation du champ contenant le checksum et du reste des informations. Calcule 
-           checksum_char = self._tampon_groupe[-1:]
-           #print("Caractere checksum : ", checksum_char)
-           checksum_calcul_chaine = self._tampon_groupe[:-1]
-           #print("Chaine checksum : ", checksum_calcul_chaine)
-           checksum_calcul_resultat = self.calcule_checksum(checksum_calcul_chaine)
+            # Separation du champ contenant le checksum et du reste des informations.
+            checksum_char = self._tampon_groupe[-1:]
+            #print("Caractere checksum : ", checksum_char)
+            checksum_calcul_chaine = self._tampon_groupe[:-1]
+            #print("Chaine checksum : ", checksum_calcul_chaine)
+            checksum_calcul_resultat = self.calcule_checksum(checksum_calcul_chaine)
 
-           # Separation du groupe de caractere dans un tableau
-           element_groupe_caractere = checksum_calul_chaine.split(self._CHAR_SEPARATEUR)
-           # On enleve le dernier element du tableau car il es vide. Il correspond au dernier donnee apres le caractere separateur, qui n'est pas suivi d'informationself
-           element_groupe_caractere = element_groupe_caractere[:-1]
-           # On recupere le nombre d'element du tableau
-           nombre_element_groupe_caractere = len(element_groupe_caractere)
+            # Separation du groupe de caractere dans un tableau
+            element_groupe_caractere = checksum_calcul_chaine.split(self._CHAR_SEPARATEUR)
+            # On enleve le dernier element du tableau car il es vide. Il correspond au dernier donnee apres le caractere separateur, qui n'est pas suivi d'informationself
+            element_groupe_caractere = element_groupe_caractere[:-1]
+            # On recupere le nombre d'element du tableau
+            nombre_element_groupe_caractere = len(element_groupe_caractere)
 
             if checksum_char == checksum_calcul_resultat:
-                # Grace au nombre d'element, on gere la présence de l'horodatage ou non
-                if nombre_element_groupe_caractere = 2
+                # Grace au nombre d'element, on gere la presence de l'horodatage ou non
+                if nombre_element_groupe_caractere == 2:
                     champ_etiquette = element_groupe_caractere[0]
                     champ_donnee=element_groupe_caractere[1]
 
                     self._t_trame_en_cours.append((champ_etiquette, champ_donnee))
 
-                elif nombre_element_groupe_caractere = 3:
+                elif nombre_element_groupe_caractere == 3:
                     champ_etiquette = element_groupe_caractere[0]
                     champ_horodatage = element_groupe_caractere[1]
                     champ_donnee = element_groupe_caractere[2]
@@ -421,91 +355,91 @@ class InterpretationTramesLinky():
         # Compteur de trames invalidees par le decodeur
         self._nbr_trames_invalides = 0
         # tableau de configuration des champs pris en compte
-        self._unite_donnee_linky = {none: (None),
-                                    wh:   ("Wh"),
-                                    varh: ("VArh"),
-                                    a:    ("A"),
-                                    v:    ("V"),
-                                    kva:  ("kVA"),
-                                    va:   ("VA"),
-                                    w:    ("W")
+        self._unite_donnee_linky = {'none': 'No Unit',
+                                    'wh':   'Wh',
+                                    'varh': 'VArh',
+                                    'a':    'A',
+                                    'v':    'V',
+                                    'kva':  'kVA',
+                                    'va':   'VA',
+                                    'w':    'W'
         }
 
         # <etiquette> : (<est numerique>, <unite donnee>, <description>)
-        self._config_champs = {"ADSC":      (False, self._unite_donnee_linky[none], "Identifiant du compteur"),
-                               "VTIC":      (False, self._unite_donnee_linky[none], "Version de la TIC"),
-                               "DATE":      (False, self._unite_donnee_linky[none], "Date et heure courante"),
-                               "NGTF":      (False, self._unite_donnee_linky[none], "Nom du calendrier tarifaire fournisseur"),
-                               "LTARF":     (False, self._unite_donnee_linky[none], "Libellé tarif fournisseur en cours"),
-                               "EAST":      (True,  self._unite_donnee_linky[wh],   "Energie active soutirée totale"),
-                               "EASF01":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 01"),
-                               "EASF02":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 02"),
-                               "EASF03":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 03"),
-                               "EASF04":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 04"),
-                               "EASF05":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 05"),
-                               "EASF06":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 06"),
-                               "EASF07":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 07"),
-                               "EASF08":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 08"),
-                               "EASF09":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 09"),
-                               "EASF10":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Fournisseur, index 10"),
-                               "EASD01":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Distributeur, index 01"),
-                               "EASD02":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Distributeur, index 02"),
-                               "EASD03":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Distributeur, index 03"),
-                               "EASD04":    (True,  self._unite_donnee_linky[wh],   "Energie active soutirée Distributeur, index 04"),
-                               "EAIT":      (True,  self._unite_donnee_linky[wh],   "Energie active injectée totale"),
-                               "ERQ1":      (True,  self._unite_donnee_linky[varh], "Energie réactive Q1 totale"),
-                               "ERQ2":      (True,  self._unite_donnee_linky[varh], "Energie réactive Q2 totale"),
-                               "ERQ3":      (True,  self._unite_donnee_linky[varh], "Energie réactive Q3 totale"),
-                               "ERQ4":      (True,  self._unite_donnee_linky[varh], "Energie réactive Q4 totale"),
-                               "IRMS1":     (True,  self._unite_donnee_linky[a],    "Courant efficace,phase 1"),
-                               "IRMS2":     (True,  self._unite_donnee_linky[a],    "Courant efficace,phase 2"),
-                               "IRMS3":     (True,  self._unite_donnee_linky[a],    "Courant efficace,phase 3"),
-                               "URMS1":     (True,  self._unite_donnee_linky[v],    "Tension efficace,phase 1"),
-                               "URMS2":     (True,  self._unite_donnee_linky[v],    "Tension efficace,phase 2"),
-                               "URMS3":     (True,  self._unite_donnee_linky[v],    "Tension efficace,phase 3"),
-                               "PREF":      (True,  self._unite_donnee_linky[kva],  "Puissance apparentes de référence"),
-                               "PCOUP":     (True,  self._unite_donnee_linky[kva],  "Puissance apparente de coupure"),
-                               "SINSTS":    (True,  self._unite_donnee_linky[va],   "Puissance apparente Instantanée soutiré"),
-                               "SINSTS1":   (True,  self._unite_donnee_linky[va],   "Puissance apparente Instantanée soutiré phase 1"),
-                               "SINSTS2":   (True,  self._unite_donnee_linky[va],   "Puissance apparente Instantanée soutiré phase 2"),
-                               "SINSTS3":   (True,  self._unite_donnee_linky[va],   "Puissance apparente Instantanée soutiré phase 3"),
-                               "SMAXSN":    (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum soutirée n"),
-                               "SMAXSN1":   (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum soutirée n phase 1"),
-                               "SMAXSN2":   (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum soutirée n phase 2"),
-                               "SMAXSN3":   (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum soutirée n phase 3"),
-                               "SMAXSN-1":  (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum soutirée n-1"),
-                               "SMAXSN1-1": (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum soutirée n-1 phase 1"),
-                               "SMAXSN2-1": (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum soutirée n-1 phase 2"),
-                               "SMAXSN3-1": (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum soutirée n-1 phase 3"),
-                               "SINSTI":    (True,  self._unite_donnee_linky[va],   "Puissance apparente Instantanée injectée"),
-                               "SMAXIN":    (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum injectée n"),
-                               "SMAXIN-1":  (True,  self._unite_donnee_linky[va],   "Puissance apparente maximum injectée n-1"),
-                               "CCASN":     (True,  self._unite_donnee_linky[w],    "Point n de la courbe de charge active soutirée"),
-                               "CCASN-1":   (True,  self._unite_donnee_linky[w],    "Point n-1 de la courbe de charge active soutirée"),
-                               "CCAIN":     (True,  self._unite_donnee_linky[w],    "Point n de la courbe de charge active injectée"),
-                               "CCAIN-1":   (True,  self._unite_donnee_linky[w],    "Point n-1 de la courbe de charge active injectée"),
-                               "UMOY1":     (True,  self._unite_donnee_linky[v],    "Tension moyenne phase 1"),
-                               "UMOY2":     (True,  self._unite_donnee_linky[v],    "Tension moyenne phase 2"),
-                               "UMOY3":     (True,  self._unite_donnee_linky[v],    "Tension moyenne phase 3"),
-                               "STGE":      (False, self._unite_donnee_linky[none], "Registre de Statuts"),
-                               "DPM1":      (False, self._unite_donnee_linky[none], "Début Pointe Mobile 1"),
-                               "FPM1":      (False, self._unite_donnee_linky[none], "Fin Pointe Mobile 1"),
-                               "DPM2":      (False, self._unite_donnee_linky[none], "Début Pointe Mobile 2"),
-                               "FPM2":      (False, self._unite_donnee_linky[none], "Fin Pointe Mobile 2"),
-                               "DPM3":      (False, self._unite_donnee_linky[none], "Début Pointe Mobile 3"),
-                               "FPM3":      (False, self._unite_donnee_linky[none], "Fin Pointe Mobile 3"),
-                               "MSG1":      (False, self._unite_donnee_linky[none], "Message Court"),
-                               "MSG2":      (False, self._unite_donnee_linky[none], "Message Ultra Court"),
-                               "PRM":       (False, self._unite_donnee_linky[none], "PRM"),
-                               "RELAIS":    (False, self._unite_donnee_linky[none], "Relais"),
-                               "NTARF":     (False, self._unite_donnee_linky[none], "Numéro de l'index tarifaire en cours"),
-                               "NJOURF":    (False, self._unite_donnee_linky[none], "Numéro du jour en cours calendrier fournisseur"),
-                               "NJOURF+1":  (False, self._unite_donnee_linky[none], "Numéro du prochain jour calendrier fournisseur"),
-                               "PJOURF+1":  (False, self._unite_donnee_linky[none], "Profil du prochain jour calendrier fournisseur"),
-                               "PPOINTE":   (False, self._unite_donnee_linky[none], "Profil du prochain jour de pointe"),
-                               "CPT_PREAVIS":          (False, self._unite_donnee_linky[none], "Compteur de nombre de fois ou le preavis de depassement de consommations a ete emis (90% puissance max)"),
-                               "CPT_TRAMES_INVALIDES": (False, self._unite_donnee_linky[none], "Nombre de trames invalides")
-        }
+        # <etiquette> : (<est numerique>, <est horodate>, <unite donnee>, <description>)
+        self._config_champs = {"ADSC":      (False, False, self._unite_donnee_linky['none'], "Identifiant du compteur"),
+                               "VTIC":      (False, False, self._unite_donnee_linky['none'], "Version de la TIC"),
+                               "DATE":      (False, False,  self._unite_donnee_linky['none'], "Date et heure courante"),
+                               "NGTF":      (False, False, self._unite_donnee_linky['none'], "Nom du calendrier tarifaire fournisseur"),
+                               "LTARF":     (False, False, self._unite_donnee_linky['none'], "Libelle tarif fournisseur en cours"),
+                               "EAST":      (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree totale"),
+                               "EASF01":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 01"),
+                               "EASF02":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 02"),
+                               "EASF03":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 03"),
+                               "EASF04":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 04"),
+                               "EASF05":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 05"),
+                               "EASF06":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 06"),
+                               "EASF07":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 07"),
+                               "EASF08":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 08"),
+                               "EASF09":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 09"),
+                               "EASF10":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Fournisseur, index 10"),
+                               "EASD01":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Distributeur, index 01"),
+                               "EASD02":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Distributeur, index 02"),
+                               "EASD03":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Distributeur, index 03"),
+                               "EASD04":    (True,  False, self._unite_donnee_linky['wh'],   "Energie active soutiree Distributeur, index 04"),
+                               "EAIT":      (True,  False, self._unite_donnee_linky['wh'],   "Energie active injectee totale"),
+                               "ERQ1":      (True,  False, self._unite_donnee_linky['varh'], "Energie reactive Q1 totale"),
+                               "ERQ2":      (True,  False, self._unite_donnee_linky['varh'], "Energie reactive Q2 totale"),
+                               "ERQ3":      (True,  False, self._unite_donnee_linky['varh'], "Energie reactive Q3 totale"),
+                               "ERQ4":      (True,  False, self._unite_donnee_linky['varh'], "Energie reactive Q4 totale"),
+                               "IRMS1":     (True,  False, self._unite_donnee_linky['a'],    "Courant efficace,phase 1"),
+                               "IRMS2":     (True,  False, self._unite_donnee_linky['a'],    "Courant efficace,phase 2"),
+                               "IRMS3":     (True,  False, self._unite_donnee_linky['a'],    "Courant efficace,phase 3"),
+                               "URMS1":     (True,  False, self._unite_donnee_linky['v'],    "Tension efficace,phase 1"),
+                               "URMS2":     (True,  False, self._unite_donnee_linky['v'],    "Tension efficace,phase 2"),
+                               "URMS3":     (True,  False, self._unite_donnee_linky['v'],    "Tension efficace,phase 3"),
+                               "PREF":      (True,  False, self._unite_donnee_linky['kva'],  "Puissance apparentes de reference"),
+                               "PCOUP":     (True,  False, self._unite_donnee_linky['kva'],  "Puissance apparente de coupure"),
+                               "SINSTS":    (True,  False, self._unite_donnee_linky['va'],   "Puissance apparente Instantanee soutiree"),
+                               "SINSTS1":   (True,  False, self._unite_donnee_linky['va'],   "Puissance apparente Instantanee soutiree phase 1"),
+                               "SINSTS2":   (True,  False, self._unite_donnee_linky['va'],   "Puissance apparente Instantanee soutiree phase 2"),
+                               "SINSTS3":   (True,  False, self._unite_donnee_linky['va'],   "Puissance apparente Instantanee soutiree phase 3"),
+                               "SMAXSN":    (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum soutiree n"),
+                               "SMAXSN1":   (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum soutiree n phase 1"),
+                               "SMAXSN2":   (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum soutiree n phase 2"),
+                               "SMAXSN3":   (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum soutiree n phase 3"),
+                               "SMAXSN-1":  (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum soutiree n-1"),
+                               "SMAXSN1-1": (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum soutiree n-1 phase 1"),
+                               "SMAXSN2-1": (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum soutiree n-1 phase 2"),
+                               "SMAXSN3-1": (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum soutiree n-1 phase 3"),
+                               "SINSTI":    (True,  False, self._unite_donnee_linky['va'],   "Puissance apparente Instantanee injectee"),
+                               "SMAXIN":    (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum injectee n"),
+                               "SMAXIN-1":  (True,  True,  self._unite_donnee_linky['va'],   "Puissance apparente maximum injectee n-1"),
+                               "CCASN":     (True,  True,  self._unite_donnee_linky['w'],    "Point n de la courbe de charge active soutiree"),
+                               "CCASN-1":   (True,  True,  self._unite_donnee_linky['w'],    "Point n-1 de la courbe de charge active soutiree"),
+                               "CCAIN":     (True,  True,  self._unite_donnee_linky['w'],    "Point n de la courbe de charge active injectee"),
+                               "CCAIN-1":   (True,  True,  self._unite_donnee_linky['w'],    "Point n-1 de la courbe de charge active injectee"),
+                               "UMOY1":     (True,  True,  self._unite_donnee_linky['v'],    "Tension moyenne phase 1"),
+                               "UMOY2":     (True,  True,  self._unite_donnee_linky['v'],    "Tension moyenne phase 2"),
+                               "UMOY3":     (True,  True,  self._unite_donnee_linky['v'],    "Tension moyenne phase 3"),
+                               "STGE":      (False, False, self._unite_donnee_linky['none'], "Registre de Statuts"),
+                               "DPM1":      (False, True,  self._unite_donnee_linky['none'], "Debut Pointe Mobile 1"),
+                               "FPM1":      (False, True,  self._unite_donnee_linky['none'], "Fin Pointe Mobile 1"),
+                               "DPM2":      (False, True,  self._unite_donnee_linky['none'], "Debut Pointe Mobile 2"),
+                               "FPM2":      (False, True,  self._unite_donnee_linky['none'], "Fin Pointe Mobile 2"),
+                               "DPM3":      (False, True,  self._unite_donnee_linky['none'], "Debut Pointe Mobile 3"),
+                               "FPM3":      (False, True,  self._unite_donnee_linky['none'], "Fin Pointe Mobile 3"),
+                               "MSG1":      (False, False, self._unite_donnee_linky['none'], "Message Court"),
+                               "MSG2":      (False, False, self._unite_donnee_linky['none'], "Message Ultra Court"),
+                               "PRM":       (False, False, self._unite_donnee_linky['none'], "PRM"),
+                               "RELAIS":    (False, False, self._unite_donnee_linky['none'], "Relais"),
+                               "NTARF":     (False, False, self._unite_donnee_linky['none'], "Numero de l'index tarifaire en cours"),
+                               "NJOURF":    (False, False, self._unite_donnee_linky['none'], "Numero du jour en cours calendrier fournisseur"),
+                               "NJOURF+1":  (False, False, self._unite_donnee_linky['none'], "Numero du prochain jour calendrier fournisseur"),
+                               "PJOURF+1":  (False, False, self._unite_donnee_linky['none'], "Profil du prochain jour calendrier fournisseur"),
+                               "PPOINTE":   (False, False, self._unite_donnee_linky['none'], "Profil du prochain jour de pointe"),
+                               "CPT_TRAMES_INVALIDES": (False, False, self._unite_donnee_linky['none'], "Nombre de trames invalides")
+            }
 
     def interpreter_trame(self, trame):
         """ Fonction d'interpretation d'une trame """
@@ -530,31 +464,43 @@ class InterpretationTramesLinky():
         nouveau_tableau_interprete = copy.deepcopy(self._dict_interprete)
         nouveau_tableau_interprete_entree_en_cours = ""
 
-        ###
-        total_conso_indep_tarif_s = 0
-        total_conso_indep_tarif_s = 0
-
-        for index, (etiquette, donnee) in enumerate(trame):
+        for index in enumerate(trame):
             unite = None
+            data = None
+            data = index[1]
+            etiquette = None
+            etiquette = data[0]
+            donnee = None
+            horodate = None
+
+            valeur_est_horodate = self._config_champs[etiquette][1]
+            if etiquette in self._config_champs:
+                if valeur_est_horodate == True:
+                    donnee = data[1]
+                    horodate = data[2]
+                else:
+                    horodate = "None"
+                    donnee = data[1]
+
+            if not "MESURE" in dict_separation_mesures:
+                dict_separation_mesures["MESURE"] = {}
+
             # Traitement specifiques pour champs structurants
             if etiquette == "ADSC":
-                dict_separation_mesures["ID_COMPTEUR"] = (donnee, self._config_champs[etiquette][1])
-            elif etiquette == "LTARF":
-                mesure_en_cours = "MESURE"
-                dict_separation_mesures["MESURE"] = {}
-                dict_separation_mesures["MESURE"]["CONTRAT"] = (donnee, self._config_champs[etiquette][1])
+                dict_separation_mesures["ID_COMPTEUR"] = (donnee, self._config_champs[etiquette][2], horodate)
+            elif etiquette == "DATE":
+                dict_separation_mesures["MESURE"][etiquette] = (data[2], self._config_champs[etiquette][2], "None")
             elif etiquette in self._config_champs:
                 if self._config_champs[etiquette][0]:
                     # Si la donnee est numerique
-                    liste_vals_numeriques = re.findall("[-+]?\d*[\.,]\d+|[-+]?\d+", donnee) # fais correspondre (match) les donnees numérique avec ou sans virgule
+                    liste_vals_numeriques = re.findall("[-+]?\d*[\.,]\d+|[-+]?\d+", donnee) # fais correspondre (match) les donnees numerique avec ou sans virgule
                     regexp = re.compile(",")
-                    valeur_numerique = regexp.sub('.', liste_vals_numerique[0])
+                    valeur_numeriques = regexp.sub('.', liste_vals_numeriques[0])
                     regexp = re.compile("[-+]?\d*[\.,]\d+|[-+]?\d+")
 
-                    dict_separation_mesures["MESURE"][etiquette] = (valeur_numerique, self._config_champs[etiquette][1])
-                else:
-                    # Sinon c'est textuel
-                    dict_separation_mesures["MESURE"][etiquette] = (donnee, self._unite_donnee_linky[none])
+                    dict_separation_mesures["MESURE"][etiquette] = (donnee, self._config_champs[etiquette][2], horodate)
+                else: # Sinon c'est textuel
+                    dict_separation_mesures["MESURE"][etiquette] = (donnee, self._config_champs[etiquette][2], horodate)
             else:
                 print("Attention, cas indetermine !!! etiquette/champ : " + etiquette + " //" + donnee)
                 print("Debut du programme sur une trame incomplete ?")
@@ -569,7 +515,7 @@ class InterpretationTramesLinky():
             interpretation_valide = False
 
         # si la trame presente le formalisme d'interpretation minimum,
-        # on met à jour le tableau de donnees interpretees du type : ...
+        # on met a jour le tableau de donnees interpretees du type : ...
         if self.__obtenir_mutex_donnees() == True:
             if interpretation_valide == True and "MESURE" in dict_separation_mesures:
 
@@ -581,12 +527,13 @@ class InterpretationTramesLinky():
                 if not "INDEP_TARIF" in nouveau_tableau_interprete:
                     nouveau_tableau_interprete["INDEP_TARIF"] = {}
                     nouveau_tableau_interprete["INDEP_TARIF"]["ID_COMPTEUR"] = copy.deepcopy(dict_separation_mesures["ID_COMPTEUR"])
-                    nouveau_tableau_interprete["INDEP_TARIF"]["CONTRAT"] = copy.deepcopy(dict_separation_mesures["MESURE"]["CONTRAT"])
+                    nouveau_tableau_interprete["INDEP_TARIF"]["CONTRAT"] = copy.deepcopy(dict_separation_mesures["MESURE"]["LTARF"])
 
                 # On boucle sur les elements {etiquette : (donnee, unite)}
                 for etiquette in dict_separation_mesures["MESURE"]:
                     donnee = dict_separation_mesures["MESURE"][etiquette][0]
                     unite = dict_separation_mesures["MESURE"][etiquette][1]
+                    horodate = dict_separation_mesures["MESURE"][etiquette][2]
 
                     # Si l'etiquette est deja dans le tableau de configuration/selection (mesure de precaution)
                     if etiquette in self._config_champs:
@@ -607,10 +554,6 @@ class InterpretationTramesLinky():
 
             # On a fini de modifier les donnees, on relache le mutex
 
-    def set_cb_nouvelle_interpretation(self, fonction):
-        """ Affectation du callback appele quand une nouvelle intrepretation est validee,
-        applique sur l'interruption - passee en parametre du callback """
-        self._cb_nouvelle_interpretation = fonction
 
     def set_cb_nouvelle_intrepretation_tt_interpretation(self, fonction):
         """ Affectation du callback appele quand une nouvelle interpretation est validee,
@@ -625,7 +568,7 @@ class InterpretationTramesLinky():
         if self.__obtenir_mutex_donnees() == True:
             if not "INDEP_TARIF" in self._dict_interprete:
                 self._dict_interprete["INDEP_TARIF"] = (None, None)
-            if not "CPT_INTERRUPTIONS" in self._dict_interprete["INDEP_TARIF"]:
+            if not "CPT_TRAMES_INVALIDES" in self._dict_interprete["INDEP_TARIF"]:
                 self._dict_interprete["INDEP_TARIF"]["CPT_TRAMES_INVALIDES"] = ("0", None)
             cpt_trames_invalides = (int(self._dict_interprete["INDEP_TARIF"]["CPT_TRAMES_INVALIDES"][0]))
             cpt_trames_invalides = cpt_trames_invalides + 1
@@ -636,7 +579,7 @@ class InterpretationTramesLinky():
     def __obtenir_mutex_donnees(self):
         """Obtention de l'exclusivite sur les donnees (mutex) """
         mutex_timeout = 5
-        epoch_demarrae = time.time()
+        epoch_demarrage = time.time()
         mutex_obtenu = False
 
         while((time.time() - epoch_demarrage) < mutex_timeout) and \

--- a/decode_linky.py
+++ b/decode_linky.py
@@ -554,6 +554,12 @@ class InterpretationTramesLinky():
 
             # On a fini de modifier les donnees, on relache le mutex
 
+    def set_cb_nouvelle_interpretation(self, fonction):
+        """
+        Affectation du callback appele quand une nouvelle intrepretation est validee,
+        applique sur l'interruption - passee en parametre du callback
+        """
+        self._cb_nouvelle_interpretation = fonction
 
     def set_cb_nouvelle_intrepretation_tt_interpretation(self, fonction):
         """ Affectation du callback appele quand une nouvelle interpretation est validee,

--- a/demo_fonctions_compteur_tic.py
+++ b/demo_fonctions_compteur_tic.py
@@ -36,8 +36,8 @@ from pickler import PicklesMyData
 chemin_sauvegarde_interpretation = "/opt/compteur_tic/sauvegarde_etat.pkl"
 periode_sauvegarde = 2 # nbr de secondes entre deux sauvegardes
 
-lecture_serie_active = True
-lecture_fichier_active = False
+lecture_serie_active = False
+lecture_fichier_active = True
 
 sortie_fichier_active = False
 
@@ -156,7 +156,7 @@ with PidFile(pidname="api_pmepmi"):
 
     # Callback appele quand un octet est recu
     def cb_nouvel_octet_recu(octet_recu):
-        decode_pmepmi.nouvel_octet(serial.to_bytes(octet_recu))
+        decodeur_trames.nouvel_octet(serial.to_bytes(octet_recu))
         if sortie_fichier_active == True:
             sortie_fichier.nouvel_octet(serial.to_bytes(octet_recu))
 
@@ -186,13 +186,18 @@ with PidFile(pidname="api_pmepmi"):
 
     # affectation des callbacks :
     if affichage_trames_gui_active == True:
-        decode_pmepmi.set_cb_nouvelle_trame_recue(cb_nouvelle_trame_recue)
+        decodeur_trames.set_cb_nouvelle_trame_recue(cb_nouvelle_trame_recue)
+
     if affichage_interpretations_gui_active:
         interpreteur_trames.set_cb_nouvelle_interpretation_tt_interpretation(cb_nouvelle_trame_interpretee_tt_interpretation)
-    decode_pmepmi.set_cb_nouvelle_trame_recue_tt_trame(interpreteur_trames.interpreter_trame)
-    decode_pmepmi.set_cb_debut_interruption(cb_debut_interruption)
-    decode_pmepmi.set_cb_fin_interruption(cb_fin_interruption)
-    decode_pmepmi.set_cb_mauvaise_trame_recue(cb_mauvaise_trame_recue)
+        
+    decodeur_trames.set_cb_nouvelle_trame_recue_tt_trame(interpreteur_trames.interpreter_trame)
+    decodeur_trames.set_cb_mauvaise_trame_recue(cb_mauvaise_trame_recue)
+
+    if type_compteur == 'pmepmi':
+        decodeur_trames.set_cb_debut_interruption(cb_debut_interruption)
+        decodeur_trames.set_cb_fin_interruption(cb_fin_interruption)
+
     if sauvegarde_etat == True:
         pickles_etat.set_callback(cb_sauvegarde_etat)
 


### PR DESCRIPTION
Bonjour,
Les caractères accentués sont supprimés, ainsi que les fonctions liées à l'interruption de trame pour Linky car elles sont inutiles.
Le code de décodage et d'interprétation Linky est corrigé.